### PR TITLE
Remove temporary workaround now that the runner fix is deployed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,14 +119,11 @@ jobs:
         with:
           release-candidate: true
 
-      - name: Add Python bin to PATH
-        if: matrix.name == 'ios' || matrix.name == 'macos'
-        run: echo "/Library/Frameworks/Python.framework/Versions/Current/bin" >> $GITHUB_PATH
-
       - name: Install Conan
         run: |
           pip3 install conan --pre --upgrade
           conan profile detect
+          
 
       - name: Print versions
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,6 @@ jobs:
         run: |
           pip3 install conan --pre --upgrade
           conan profile detect
-          
 
       - name: Print versions
         run: |


### PR DESCRIPTION
Now that https://github.com/actions/runner-images/issues/6507 is fixed and deployed, remove manual add of python bin to PATH.