### PR TITLE
Add VS Code configs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-vscode.cmake-tools",
+    "ms-vscode.cpptools",
+    "vadimcn.vscode-lldb"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "CMake: Launch (macOS/Linux / LLDB)",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${command:cmake.launchTargetPath}",
+      "args": [
+        // Example: pass arguments to your program
+        // "arg1", "arg2=value", "--flag"
+      ],
+      "cwd": "${command:cmake.launchTargetDirectory}",
+      "stopOnEntry": false,
+      "env": {
+        // Example: set environment variables for your program
+        // "MY_VAR": "value"
+      },
+      "terminal": "integrated"
+    },
+    {
+      "name": "CMake: Launch (Windows / MSVC)",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "program": "${command:cmake.launchTargetPath}",
+      "args": [
+        // Example: pass arguments to your program
+        // "arg1", "arg2=value", "--flag"
+      ],
+      "cwd": "${command:cmake.launchTargetDirectory}",
+      "stopAtEntry": false,
+      "environment": [
+        // Example: set environment variables for your program
+        // { "name": "MY_VAR", "value": "value" }
+      ]
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,8 +9,7 @@
         {
             "name": "default",
             "hidden": true,
-            "binaryDir": "${sourceDir}/build_${presetName}",
-            "cmakeExecutable": "cmake.exe"
+            "binaryDir": "${sourceDir}/build_${presetName}"
         },
         {
             "name": "iwyu",

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) to make it easy
 1. Run `cmake --workflow --list-presets` to see available presets
 1. Run `cmake --workflow --preset=<preset-name>` to run the full CMake workflow for that build (example: macOS build/test/packaging with release build config would be `cmake --workflow --preset=macosRelease`).
 
+#### Build with VS Code
+1. Install [recommended extensions](.vscode/extensions.json) from the Extensions sidebar
+1. Configure presets and Debug/Launch targets in the CMake sidebar
+1. Click the Build icon in the status bar to build
+1. Select your platform launcher in the "Run and Debug" sidebar and click play to debug
+1. Run tests from the Tests sidebar
+
 ## Continuous integration (CI)
 The build process is automated through [GitHub Actions](https://github.com/features/actions), defined in the [main.yml](.github/workflows/main.yml) file. Nothing fancy here, it runs CMake's configure, build, test, and package commands and archives the results.
 

--- a/cmake/global_settings.cmake
+++ b/cmake/global_settings.cmake
@@ -102,3 +102,18 @@ set(CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR}/_install)
 set(CPACK_PACKAGE_DIRECTORY ${PROJECT_BINARY_DIR}/_package/\${CPACK_BUILD_CONFIG})
 set(CPACK_COMPONENTS_GROUPING IGNORE)
 set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY 0)
+
+# Fix for VS Code's Quick Debugging error "No compiler found in the cache file."
+# when using CMake's Xcode generator.
+# Note: Quick Debugging is the "Launch the debugger" icon in the status bar at the bottom,
+# not to be confused with "Start Debugging" in the Run menu and in the "Run and Debug"
+# Activity Bar, which is controlled by .vscode/launch.json")
+if(CMAKE_GENERATOR MATCHES "Xcode" AND NOT DEFINED CMAKE_COMPILER_FORCED)
+    foreach(lang C CXX)
+        set(CMAKE_${lang}_COMPILER "${CMAKE_${lang}_COMPILER}" 
+            CACHE STRING "Detected ${lang} compiler" FORCE)
+    endforeach()
+
+    set(CMAKE_COMPILER_FORCED TRUE CACHE INTERNAL "Mark compiler as forced")
+endif()
+


### PR DESCRIPTION
Add easy debugging in VS Code for Windows, macOS, and Linux apps. Also, add all extensions I used in the "recommendations" so they're more discoverable for developers to install.